### PR TITLE
Add support for attachments

### DIFF
--- a/lib/database_backend.dart
+++ b/lib/database_backend.dart
@@ -34,6 +34,14 @@ Future<int> insertNewsInDB(NewsList newsList, FluxNewsState appState) async {
       // if the news is not present, insert the news
       if (resultSelect.isEmpty) {
         result = await appState.db!.insert('news', news.toMap());
+
+        // insert the first image attachment of the news in the attachments db
+        Attachment immageAttachment = news.getFirstImmageAttachment();
+        if (immageAttachment.attachmentID != -1) {
+          result = await appState.db!
+              .insert('attachments', immageAttachment.toMap());
+        }
+
         if (appState.debugMode) {
           FlutterLogs.logThis(
               tag: FluxNewsState.logTag,
@@ -262,9 +270,12 @@ Future<List<News>> queryNewsFromDB(
                       news.feedTitle, 
                       news.syncStatus,
                       feeds.icon,
-                      feeds.iconMimeType 
+                      feeds.iconMimeType,
+                      attachments.attachmentURL,
+                      attachments.attachmentMimeType
                 FROM news 
                 LEFT OUTER JOIN feeds ON news.feedID = feeds.feedID
+                LEFT OUTER JOIN attachments ON news.newsID = attachments.newsID
                 WHERE news.starred = ? 
                 ORDER BY news.publishedAt $sortOrder''', [1]);
         newList.addAll(queryResult.map((e) => News.fromMap(e)).toList());
@@ -286,9 +297,12 @@ Future<List<News>> queryNewsFromDB(
                       news.feedTitle, 
                       news.syncStatus,
                       feeds.icon,
-                      feeds.iconMimeType 
+                      feeds.iconMimeType,
+                      attachments.attachmentURL,
+                      attachments.attachmentMimeType 
                   FROM news 
                   LEFT OUTER JOIN feeds ON news.feedID = feeds.feedID
+                  LEFT OUTER JOIN attachments ON news.newsID = attachments.newsID
                   WHERE (news.status LIKE ?) 
                     AND news.feedID LIKE ? 
                   ORDER BY news.publishedAt $sortOrder''', [status, feedID]);
@@ -312,9 +326,12 @@ Future<List<News>> queryNewsFromDB(
                       news.feedTitle, 
                       news.syncStatus,
                       feeds.icon,
-                      feeds.iconMimeType
+                      feeds.iconMimeType,
+                      attachments.attachmentURL,
+                      attachments.attachmentMimeType
               FROM news 
               LEFT OUTER JOIN feeds ON news.feedID = feeds.feedID
+              LEFT OUTER JOIN attachments ON news.newsID = attachments.newsID
               WHERE (news.status LIKE ?) 
               ORDER BY news.publishedAt $sortOrder''', [status]);
       newList.addAll(queryResult.map((e) => News.fromMap(e)).toList());

--- a/lib/flux_news_state.dart
+++ b/lib/flux_news_state.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_logs/flutter_logs.dart';
@@ -195,7 +197,40 @@ class FluxNewsState extends ChangeNotifier {
             logMessage: 'Finished creating DB',
             level: LogLevel.INFO);
       },
-      version: 1,
+      onUpgrade: (db, oldVersion, newVersion) async {
+        if (Platform.isAndroid || Platform.isIOS) {
+          FlutterLogs.logThis(
+              tag: FluxNewsState.logTag,
+              subTag: 'upgradeDB',
+              logMessage: 'Starting upgrading DB',
+              level: LogLevel.INFO);
+        }
+        if (oldVersion == 1) {
+          if (Platform.isAndroid || Platform.isIOS) {
+            FlutterLogs.logThis(
+                tag: FluxNewsState.logTag,
+                subTag: 'upgradeDB',
+                logMessage: 'Updgrading DB from version 1',
+                level: LogLevel.INFO);
+          }
+          // create the table attachments
+          await db.execute('DROP TABLE IF EXISTS attachments');
+          await db.execute(
+            '''CREATE TABLE attachments(attachmentID INTEGER PRIMARY KEY, 
+                          newsID INTEGER, 
+                          attachmentURL TEXT, 
+                          attachmentMimeType TEXT)''',
+          );
+        }
+        if (Platform.isAndroid || Platform.isIOS) {
+          FlutterLogs.logThis(
+              tag: FluxNewsState.logTag,
+              subTag: 'upgradeDB',
+              logMessage: 'Finished upgrading DB',
+              level: LogLevel.INFO);
+        }
+      },
+      version: 2,
     );
   }
 

--- a/lib/flux_news_state.dart
+++ b/lib/flux_news_state.dart
@@ -30,7 +30,7 @@ class FluxNewsState extends ChangeNotifier {
 
   // define static const variables to replace text within code
   static const String applicationName = 'Flux News';
-  static const String applicationVersion = '1.1.3';
+  static const String applicationVersion = '1.2.1';
   static const String applicationLegalese = '\u{a9} 2023 Kevin Fechtel';
   static const String applicationProjectUrl =
       ' https://github.com/KevinCFechtel/FluxNews';
@@ -190,6 +190,14 @@ class FluxNewsState extends ChangeNotifier {
                           iconMimeType TEXT,
                           newsCount INTEGER,
                           categorieID INTEGER)''',
+        );
+        // create the table attachments
+        await db.execute('DROP TABLE IF EXISTS attachments');
+        await db.execute(
+          '''CREATE TABLE attachments(attachmentID INTEGER PRIMARY KEY, 
+                          newsID INTEGER, 
+                          attachmentURL TEXT, 
+                          attachmentMimeType TEXT)''',
         );
         FlutterLogs.logThis(
             tag: FluxNewsState.logTag,

--- a/lib/miniflux_backend.dart
+++ b/lib/miniflux_backend.dart
@@ -341,7 +341,7 @@ Future<List<News>> fetchSearchedNews(
         throw FluxNewsState.httpUnexpectedResponseErrorString;
       }
     }
-    // Auslesen der Feed Icons
+    // read the feed icon
     // check if the database is initialized
     // if not, initialize the database
     appState.db ??= await appState.initializeDB();
@@ -807,27 +807,40 @@ Future<bool> checkMinifluxCredentials(http.Client client, String? miniFluxUrl,
         await client.get(Uri.parse('${miniFluxUrl}me'), headers: header);
     if (response.statusCode == 200) {
       if (appState.debugMode) {
-        // need to remove the "v1/" part from the url to request the version api endpoint
-        String minifluxBaseURL = "";
-        if (miniFluxUrl.length >= 3) {
-          minifluxBaseURL = miniFluxUrl.substring(0, miniFluxUrl.length - 3);
-        }
-
-        response = await client.get(Uri.parse('${minifluxBaseURL}version'),
+        // request the Version of the miniflux server
+        response = await client.get(Uri.parse('${miniFluxUrl}version'),
             headers: header);
         if (response.statusCode == 200) {
+          Version minifluxVersion =
+              Version.fromJson(jsonDecode(utf8.decode(response.bodyBytes)));
           FlutterLogs.logThis(
               tag: FluxNewsState.logTag,
               subTag: 'checkMinifluxCredentials',
-              logMessage: 'Miniflux Version: ${response.body}',
+              logMessage: 'Miniflux v1 API Version: ${minifluxVersion.version}',
               level: LogLevel.INFO);
         } else {
-          FlutterLogs.logThis(
-              tag: FluxNewsState.logTag,
-              subTag: 'checkMinifluxCredentials',
-              logMessage:
-                  'Got unexpected response from miniflux server: ${response.statusCode} for version',
-              level: LogLevel.ERROR);
+          // need to remove the "v1/" part from the url to request the version api endpoint
+          String minifluxBaseURL = "";
+          if (miniFluxUrl.length >= 3) {
+            minifluxBaseURL = miniFluxUrl.substring(0, miniFluxUrl.length - 3);
+          }
+
+          response = await client.get(Uri.parse('${minifluxBaseURL}version'),
+              headers: header);
+          if (response.statusCode == 200) {
+            FlutterLogs.logThis(
+                tag: FluxNewsState.logTag,
+                subTag: 'checkMinifluxCredentials',
+                logMessage: 'Miniflux Version: ${response.body}',
+                level: LogLevel.INFO);
+          } else {
+            FlutterLogs.logThis(
+                tag: FluxNewsState.logTag,
+                subTag: 'checkMinifluxCredentials',
+                logMessage:
+                    'Got unexpected response from miniflux server: ${response.statusCode} for version',
+                level: LogLevel.ERROR);
+          }
         }
         FlutterLogs.logThis(
             tag: FluxNewsState.logTag,

--- a/lib/news_model.dart
+++ b/lib/news_model.dart
@@ -460,7 +460,7 @@ class Categories {
   }
 }
 
-// define the model for a categorie
+// define the model for a Attachment
 class Attachment {
   Attachment(
       {required this.attachmentID,
@@ -500,4 +500,38 @@ class Attachment {
         newsID = res['newsID'],
         attachmentURL = res['attachmentURL'],
         attachmentMimeType = res['attachmentMimeType'];
+}
+
+// define the model for Version response
+class Version {
+  Version(
+      {required this.version,
+      required this.commit,
+      required this.buildDate,
+      required this.goVersion,
+      required this.compiler,
+      required this.arch,
+      required this.os});
+
+  // define the properties
+  String version = '';
+  String commit = '';
+  String buildDate = '';
+  String goVersion = '';
+  String compiler = '';
+  String arch = '';
+  String os = '';
+
+  // define the method to convert the model from json
+  factory Version.fromJson(Map<String, dynamic> json) {
+    return Version(
+      version: json['version'],
+      commit: json['commit'],
+      buildDate: json['build_date'],
+      goVersion: json['go_version'],
+      compiler: json['compiler'],
+      arch: json['arch'],
+      os: json['os'],
+    );
+  }
 }

--- a/lib/news_model.dart
+++ b/lib/news_model.dart
@@ -49,7 +49,7 @@ class News {
 
   // define the method to convert the json to the model
   factory News.fromJson(Map<String, dynamic> json) {
-    return News(
+    News news = News(
       newsID: json['id'],
       feedID: json['feed_id'],
       title: json['title'],
@@ -62,8 +62,14 @@ class News {
       readingTime: json['reading_time'],
       starred: json['starred'],
       feedTitel: json['feed']?['title'],
-      attachments: json['enclosures'],
     );
+
+    if (json['enclosures'] != null) {
+      news.attachments = List<Attachment>.from(
+          json['enclosures'].map((i) => Attachment.fromJson(i)));
+    }
+
+    return news;
   }
 
   // define the method to convert the model to the database
@@ -133,6 +139,23 @@ class News {
     return text;
   }
 
+  Attachment getFirstImmageAttachment() {
+    Attachment imageAttachment = Attachment(
+        attachmentID: -1,
+        newsID: -1,
+        attachmentURL: "",
+        attachmentMimeType: "");
+
+    if (attachments != null) {
+      for (var attachment in attachments!) {
+        if (attachment.attachmentMimeType.startsWith("image")) {
+          imageAttachment = attachment;
+        }
+      }
+    }
+    return imageAttachment;
+  }
+
   // define the method to extract the image url from the html content
   // the image url is searched in the img tags
   // the image url is searched in the src attribute
@@ -148,6 +171,11 @@ class News {
         if (attrib.startsWith('http')) {
           imageUrl = attrib;
         }
+      }
+    }
+    if (imageUrl == FluxNewsState.noImageUrlString) {
+      if (attachmentURL != null) {
+        imageUrl = attachmentURL!;
       }
     }
     return imageUrl;

--- a/lib/news_model.dart
+++ b/lib/news_model.dart
@@ -23,7 +23,10 @@ class News {
       required this.status,
       required this.readingTime,
       required this.starred,
-      required this.feedTitel});
+      required this.feedTitel,
+      this.attachments,
+      this.attachmentURL,
+      this.attachmentMimeType});
   // define the properties
   int newsID = 0;
   int feedID = 0;
@@ -40,6 +43,9 @@ class News {
   String? syncStatus = FluxNewsState.notSyncedSyncStatus;
   Uint8List? icon;
   String? iconMimeType = '';
+  List<Attachment>? attachments;
+  String? attachmentURL = '';
+  String? attachmentMimeType = '';
 
   // define the method to convert the json to the model
   factory News.fromJson(Map<String, dynamic> json) {
@@ -56,6 +62,7 @@ class News {
       readingTime: json['reading_time'],
       starred: json['starred'],
       feedTitel: json['feed']?['title'],
+      attachments: json['enclosures'],
     );
   }
 
@@ -94,7 +101,9 @@ class News {
         feedTitel = res['feedTitle'],
         syncStatus = res['syncStatus'],
         icon = res['icon'],
-        iconMimeType = res['iconMimeType'];
+        iconMimeType = res['iconMimeType'],
+        attachmentURL = res['attachmentURL'],
+        attachmentMimeType = res['attachmentMimeType'];
 
   // define the method to extract the text from the html content
   // the text is first searched in the raw text
@@ -421,4 +430,46 @@ class Categories {
       appState.refreshView();
     }
   }
+}
+
+// define the model for a categorie
+class Attachment {
+  Attachment(
+      {required this.attachmentID,
+      required this.newsID,
+      required this.attachmentURL,
+      required this.attachmentMimeType});
+
+  // define the properties
+  int attachmentID = 0;
+  int newsID = 0;
+  String attachmentURL = '';
+  String attachmentMimeType = '';
+
+  // define the method to convert the model from json
+  factory Attachment.fromJson(Map<String, dynamic> json) {
+    return Attachment(
+      attachmentID: json['id'],
+      newsID: json['entry_id'],
+      attachmentURL: json['url'],
+      attachmentMimeType: json['mime_type'],
+    );
+  }
+
+  // define the method to convert the model to database
+  Map<String, dynamic> toMap() {
+    return {
+      'attachmentID': attachmentID,
+      'newsID': newsID,
+      'attachmentURL': attachmentURL,
+      'attachmentMimeType': attachmentMimeType,
+    };
+  }
+
+  // define the method to convert the model from database
+  Attachment.fromMap(Map<String, dynamic> res)
+      : attachmentID = res['attachmentID'],
+        newsID = res['newsID'],
+        attachmentURL = res['attachmentURL'],
+        attachmentMimeType = res['attachmentMimeType'];
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: "20071638cbe4e5964a427cfa0e86dce55d060bc7d82d56f3554095d7239a8765"
+      sha256: "7e0d52067d05f2e0324268097ba723b71cb41ac8a6a2b24d1edf9c536b987b03"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.2"
+    version: "3.4.6"
   args:
     dependency: transitive
     description:
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "0713a05b0386bd97f9e63e78108805a4feca5898a4b821d6610857f10c91e975"
+      sha256: "64e12b0521812d1684b1917bc80945625391cb9bdd4312536b1d69dcb6133ed8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   build_runner:
     dependency: "direct dev"
     description:
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: fd832b5384d0d6da4f6df60b854d33accaaeb63aa9e10e736a87381f08dee2cb
+      sha256: "445db18de832dba8d851e287aff8ccf169bed30d2e94243cb54c7d2f1ed2142c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3+5"
+    version: "0.3.3+6"
   crypto:
     dependency: transitive
     description:
@@ -245,10 +245,10 @@ packages:
     dependency: "direct main"
     description:
       name: dynamic_color
-      sha256: "96bff3df72e3d428bda2b874c7a521e8c86f592cae626ea594922fcc8d166e0c"
+      sha256: "8b8bd1d798bd393e11eddeaa8ae95b12ff028bf7d5998fc5d003488cd5f4ce2f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.7"
+    version: "1.6.8"
   equatable:
     dependency: "direct main"
     description:
@@ -335,10 +335,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_native_splash
-      sha256: ecff62b3b893f2f665de7e4ad3de89f738941fcfcaaba8ee601e749efafa4698
+      sha256: "5bf4c3e5e5a0426c1e2fc8ca3555a9e617e76369c3442e1dae8385c7767ba97a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.4"
   flutter_oss_licenses:
     dependency: "direct main"
     description:
@@ -417,10 +417,10 @@ packages:
     dependency: "direct main"
     description:
       name: font_awesome_flutter
-      sha256: "5fb789145cae1f4c3245c58b3f8fb287d055c26323879eab57a7bf0cfd1e45f3"
+      sha256: "52671aea66da73b58d42ec6d0912b727a42248dd9a7c76d6c20f275783c48c08"
       url: "https://pub.dev"
     source: hosted
-    version: "10.5.0"
+    version: "10.6.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -673,10 +673,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: ae68c7bfcd7383af3629daafb32fb4e8681c7154428da4febcff06200585f102
+      sha256: "0a279f0707af40c890e80b1e9df8bb761694c074ba7e1d4ab1bc4b728e200b59"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -745,18 +745,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "6cec740fa0943a826951223e76218df002804adb588235a8910dc3d6b0654e11"
+      sha256: f74fc3f1cbd99f39760182e176802f693fa0ec9625c045561cfad54681ea93dd
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.2.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "357412af4178d8e11d14f41723f80f12caea54cf0d5cd29af9dcdab85d58aea7"
+      sha256: df08bc3a07d01f5ea47b45d03ffcba1fa9cd5370fb44b3f38c70e42cced0f956
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.1"
   shelf:
     dependency: transitive
     description:
@@ -794,6 +794,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   sqflite:
     dependency: "direct main"
     description:
@@ -982,34 +990,34 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      sha256: b715b8d3858b6fa9f68f87d20d98830283628014750c2b09b6f516c1da4af2a7
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.7"
+    version: "4.1.0"
   vector_graphics:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "670f6e07aca990b4a2bcdc08a784193c4ccdd1932620244c3a86bb72a0eac67f"
+      sha256: b16dadf7eb610e20da044c141b4a0199a5e8082ca21daba68322756f953ce714
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.7"
+    version: "1.1.9"
   vector_graphics_codec:
     dependency: transitive
     description:
       name: vector_graphics_codec
-      sha256: "7451721781d967db9933b63f5733b1c4533022c0ba373a01bdd79d1a5457f69f"
+      sha256: a4b01403d5c613db115e30e71eca33f7e9e09f2d3c52c3fb84e16333ecddc539
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.7"
+    version: "1.1.9"
   vector_graphics_compiler:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "80a13c613c8bde758b1464a1755a7b3a8f2b6cec61fbf0f5a53c94c30f03ba2e"
+      sha256: d26c0e2f237476426523eb25512e4c09fa27c6d33ed659a0e69d79e20b5dc47f
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.7"
+    version: "1.1.9"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.3+202309271
+version: 1.2.1+202310231
 
 environment:
   sdk: '>=2.19.5 <3.0.0'


### PR DESCRIPTION
Now, images attached to a news entry are supported as news images.
For this feature, a Miniflux version >= 2.0.49 is required.
In this case, the first attached image is used as the news image if no image was previously specified in the content of the entry.
Additionally, the "Version" API endpoint has been updated.