### PR TITLE
fix: save to third party not work if miniflux version >= 2.1

### DIFF
--- a/lib/news_widget_functions.dart
+++ b/lib/news_widget_functions.dart
@@ -76,8 +76,7 @@ void showContextMenu(News news, BuildContext context, bool searchView,
         ),
         // save the news to third party service
         PopupMenuItem(
-            enabled: appState.minifluxVersionInt >=
-                FluxNewsState.minifluxSaveMinVersion,
+            enabled: appState.minifluxVersionString!.startsWith(RegExp(r'[01]|2\.0')) ? appState.minifluxVersionInt >= FluxNewsState.minifluxSaveMinVersion : true,
             value: FluxNewsState.contextMenuSaveString,
             child: Row(children: [
               const Icon(


### PR DESCRIPTION
## Description
Fix if Miniflux's version is >= 2.1.0, the "Save to third party" menu item will be disabled. 